### PR TITLE
ftntickpost.in: stop using of comma-less variables

### DIFF
--- a/src/tick/ftntickpost.in
+++ b/src/tick/ftntickpost.in
@@ -30,7 +30,7 @@ File          Size       Area             Origin         From
 
 format BODY =
 @<<<<<<<<<<<< @<<<<<<<<< @<<<<<<<<<<<<<<< @<<<<<<<<<<<<< @<<<<<<<<<<<<<<<<
-$tic{file}    $tic{size} $tic{area}   $tic{origin}  $tic{from}
+$tic{file},   $tic{size},$tic{area},      $tic{origin},  $tic{from}
                          ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
 			 $tic{desc}
 ~~                       ^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<


### PR DESCRIPTION
Comaless variable list is deprecated in Perl for a long time and this throws a fatal error in Perl 5.28 and later.

Signed-off-by: Eugene Subbotin <evs@subbotin.org>