### PR TITLE
Seprate tic password

### DIFF
--- a/configs/passwd.sample
+++ b/configs/passwd.sample
@@ -40,7 +40,8 @@ packet	2:5030/1229.777		XXXXXXXX
 #
 # Context "af" - areafix passwords for ftnaf
 #         "ff" - filefix passwords for ftnaf -F,
-#                tick passwords for ftnhatch, ftntick.
+#                tick passwords for ftnhatch, ftntick (--disable-tick-password).
+#        "tic" - tick passwords for ftnhatch, ftntick (--enable-tick-password).
 #
 #					lvl key   name
 #					--- ---   ----

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ dnl Copyright (c) 2003-2008 Andrey Slusar <anrays@gmail.com>
 dnl Copyright (c) 2003-2004 Alexandr Dobroslavskiy <dsas@users.sourceforge.net>
 dnl Copyright (c) 2015-2020 Yauheni Kaliuta <y.kaliuta@gmail.com>
 dnl
-AC_REVISION([Revision: 1033])
+AC_REVISION([Revision: 1035])
 AC_PREREQ(2.53)
 AC_INIT([fidogate],[5.8],[y.kaliuta@gmail.com])
 AC_DISABLE_OPTION_CHECKING
@@ -576,6 +576,36 @@ if test $enable_tick_crc = yes; then
 	      [Enable if no ftntick CRC control])
 fi
 
+AC_ARG_ENABLE(tick-history,
+[  --disable-tick-history  tick dupe check],dnl
+   [case "${enableval}" in
+    yes) enable_tick_history=yes ;;
+     no) enable_tick_history=no ;;
+      *) AC_MSG_ERROR(bad value ${enableval} for --disable-tick-history) ;;
+    esac],dnl
+    enable_tick_history=yes)
+
+if test $enable_tick_history = yes; then
+    AC_DEFINE(TIC_HISTORY,
+              1,
+	      [Enable tic dupe check])
+fi
+
+AC_ARG_ENABLE(tick-password,
+[  --enable-tick-password  enable separate tic password in passwd file],dnl
+   [case "${enableval}" in
+    yes) enable_tick_password=yes ;;
+     no) enable_tick_password=no ;;
+      *) AC_MSG_ERROR(bad value ${enableval} for --enable-tick-password) ;;
+    esac],dnl
+    enable_tick_password=no)
+
+if test $enable_tick_password = yes; then
+    AC_DEFINE(TIC_PASSWORD,
+              1,
+	      [Enable separate tic password in passwd file])
+fi
+
 AC_ARG_ENABLE(no-organization,
 [  --enable-no-organization enable if no insert Origin line if it absence],dnl
    [case "${enableval}" in
@@ -689,21 +719,6 @@ if test $enable_pid2rd_tid2gtv = yes; then
               1,
 	      [Enable paste ^PID (mail or news reader name)
 	      and ^TID (fidogate version) kludge])
-fi
-
-AC_ARG_ENABLE(tick-history,
-[  --disable-tick-history  tick dupe check],dnl
-   [case "${enableval}" in
-    yes) enable_tick_history=yes ;;
-     no) enable_tick_history=no ;;
-      *) AC_MSG_ERROR(bad value ${enableval} for --disable-tick-history) ;;
-    esac],dnl
-    enable_tick_history=yes)
-
-if test $enable_tick_history = yes; then
-    AC_DEFINE(TIC_HISTORY,
-              1,
-	      [Enable tic dupe check])
 fi
 
 AC_ARG_ENABLE(dnt-netmail,

--- a/src/tick/ftnhatch.c
+++ b/src/tick/ftnhatch.c
@@ -38,7 +38,11 @@
 #define CREATOR		"by FIDOGATE/ftnhatch"
 
 #define MY_AREASBBS	"FAreasBBS"
+#ifdef TIC_PASSWORD
+#define MY_CONTEXT	"tic"
+#else
 #define MY_CONTEXT	"ff"
+#endif                          /* TIC_PASSWORD */
 
 /*
  * Prototypes

--- a/src/tick/ftntick.c
+++ b/src/tick/ftntick.c
@@ -37,7 +37,11 @@
 #define CONFIG		DEFAULT_CONFIG_MAIN
 
 #define MY_AREASBBS	"FAreasBBS"
+#ifdef TIC_PASSWORD
+#define MY_CONTEXT	"tic"
+#else
 #define MY_CONTEXT	"ff"
+#endif                          /* TIC_PASSWORD */
 
 #define MY_FILESBBS	"files.bbs"
 


### PR DESCRIPTION
Some uplinks are using separate passwords for FileFix and tic.
This commit adds the --enable-tick-password option to configure
and defines TIC_PASSWORD to change the password context in passwd
file. When this option is enabled, tic password should be added
as separate string to the passwd file in the following way:

tic    2:5075/35    password