### PR TITLE
Configurable support for T-Mail File Boxes flavours

### DIFF
--- a/configs/fidogate.conf.sample.in
+++ b/configs/fidogate.conf.sample.in
@@ -434,6 +434,9 @@ AutoCreateFechoPath /home/ftp/fileecho
 # Filebox style directory. In it create hardlinks to our downlinks
 PassthroughtBoxesDir %B/fbox
 
+# Enable T-Mail compatible Hold flavour support in filebox directory name
+BoxesWithFlavours
+
 # Time in hour to wait file if it missing, if tick file was resived
 TickWaitHour 48
 

--- a/configure.ac
+++ b/configure.ac
@@ -562,20 +562,6 @@ if test $enable_use_filebox = yes; then
 	      [Enable if use fileboxes for fileecho])
 fi
 
-AC_ARG_ENABLE(filebox-flavour,
-[  --disable-filebox-flavour   use flavour in fileboxes names],dnl
-   [case "${enableval}" in
-    yes | no) enable_filebox_flavour="${enableval}" ;;
-      *) AC_MSG_ERROR(bad value ${enableval} for --disable-filebox-flavour) ;;
-    esac],dnl
-    enable_filebox_flavour=yes)
-
-if test $enable_filebox_flavour = yes; then
-    AC_DEFINE(FILEBOX_FLAVOUR,
-              1,
-	      [Enable flavour in fileboxes names])
-fi
-
 AC_ARG_ENABLE(tick-crc,
 [  --disable-tick-crc      ftntick CRC control],dnl
    [case "${enableval}" in

--- a/configure.ac
+++ b/configure.ac
@@ -562,6 +562,20 @@ if test $enable_use_filebox = yes; then
 	      [Enable if use fileboxes for fileecho])
 fi
 
+AC_ARG_ENABLE(filebox-flavour,
+[  --disable-filebox-flavour   use flavour in fileboxes names],dnl
+   [case "${enableval}" in
+    yes | no) enable_filebox_flavour="${enableval}" ;;
+      *) AC_MSG_ERROR(bad value ${enableval} for --disable-filebox-flavour) ;;
+    esac],dnl
+    enable_filebox_flavour=yes)
+
+if test $enable_filebox_flavour = yes; then
+    AC_DEFINE(FILEBOX_FLAVOUR,
+              1,
+	      [Enable flavour in fileboxes names])
+fi
+
 AC_ARG_ENABLE(tick-crc,
 [  --disable-tick-crc      ftntick CRC control],dnl
    [case "${enableval}" in

--- a/doc/README.ru
+++ b/doc/README.ru
@@ -1015,6 +1015,10 @@ AutoCreateFechoPath /home/ftp/fileecho
 # хардлинки.
 PassthroughtBoxesDir /var/spool/bt/fbox
 
+# Формировать имена каталогов транзитных файлбоксов с учетом flavour Hold
+# для совместимость с T-Mail или BinkD (добавлять ".H" в конце)
+BoxesWithFlavours
+
 # Время в часах, в течении которого ожидаем прихода файла для соотв. tic'а.
 TickWaitHour 168
 

--- a/src/common/tick.c
+++ b/src/common/tick.c
@@ -323,19 +323,16 @@ int tick_send(Tick * tic, Node * node, char *name, mode_t mode)
             fglog("$ERROR: config: PassthroughtBoxesDir not defined");
             return ERROR;
         }
-#ifndef FILEBOX_FLAVOUR
+
         str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
                    pass_path, node->zone, node->net, node->node, node->point);
-#else
-        if (!strcmp(flav, "Hold"))
-            str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d.H",
-                       pass_path,
-                       node->zone, node->net, node->node, node->point);
-        else
-            str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
-                       pass_path,
-                       node->zone, node->net, node->node, node->point);
-#endif
+
+        /* 
+        * Check for BoxesWithFlavours support and add Hold flavour if needed
+        */
+        if (streq(flav, "Hold") && (cf_get_string("BoxesWithFlavours", TRUE) != NULL))
+            BUF_APPEND(buffer, ".H");
+
         if (mkdir_r(buffer, DIR_MODE) == ERROR) {
             fglog("$WARNING: can't create dir %s", buffer);
             return ERROR;
@@ -404,19 +401,16 @@ int tick_send(Tick * tic, Node * node, char *name, mode_t mode)
         fglog("$ERROR: config: PassthroughtBoxesDir not defined");
         return ERROR;
     }
-#ifndef FILEBOX_FLAVOUR
+
     str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
                pass_path, node->zone, node->net, node->node, node->point);
-#else
-    if (!strcmp(flav, "Hold"))
-        str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d.H",
-                   pass_path,
-                   node->zone, node->net, node->node, node->point);
-    else
-        str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
-                   pass_path,
-                   node->zone, node->net, node->node, node->point);
-#endif
+
+    /* 
+     * Check for BoxesWithFlavours support and add Hold flavour if needed
+     */
+    if (streq(flav, "Hold") && (cf_get_string("BoxesWithFlavours", TRUE) != NULL))
+        BUF_APPEND(buffer, ".H");
+
     if (mkdir_r(buffer, DIR_MODE) == ERROR) {
         fglog("$ERROR: can't create dir %s", buffer);
         return ERROR;

--- a/src/common/tick.c
+++ b/src/common/tick.c
@@ -323,10 +323,19 @@ int tick_send(Tick * tic, Node * node, char *name, mode_t mode)
             fglog("$ERROR: config: PassthroughtBoxesDir not defined");
             return ERROR;
         }
-
+#ifndef FILEBOX_FLAVOUR
         str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
                    pass_path, node->zone, node->net, node->node, node->point);
-
+#else
+        if (!strcmp(flav, "Hold"))
+            str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d.H",
+                       pass_path,
+                       node->zone, node->net, node->node, node->point);
+        else
+            str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
+                       pass_path,
+                       node->zone, node->net, node->node, node->point);
+#endif
         if (mkdir_r(buffer, DIR_MODE) == ERROR) {
             fglog("$WARNING: can't create dir %s", buffer);
             return ERROR;
@@ -395,9 +404,19 @@ int tick_send(Tick * tic, Node * node, char *name, mode_t mode)
         fglog("$ERROR: config: PassthroughtBoxesDir not defined");
         return ERROR;
     }
-
+#ifndef FILEBOX_FLAVOUR
     str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
                pass_path, node->zone, node->net, node->node, node->point);
+#else
+    if (!strcmp(flav, "Hold"))
+        str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d.H",
+                   pass_path,
+                   node->zone, node->net, node->node, node->point);
+    else
+        str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
+                   pass_path,
+                   node->zone, node->net, node->node, node->point);
+#endif
     if (mkdir_r(buffer, DIR_MODE) == ERROR) {
         fglog("$ERROR: can't create dir %s", buffer);
         return ERROR;


### PR DESCRIPTION
Added configurable support for T-Mail File Boxes flavours
compatible to BinkD implementation. Feature is enabled by
default and may be disabled by passing --disable-filebox-flavour
to the configure script.