### PR TITLE
tick: added tick flavour support for passthrough fileboxes

### DIFF
--- a/configs/fidogate.conf.sample.in
+++ b/configs/fidogate.conf.sample.in
@@ -434,6 +434,9 @@ AutoCreateFechoPath /home/ftp/fileecho
 # Filebox style directory. In it create hardlinks to our downlinks
 PassthroughtBoxesDir %B/fbox
 
+# Enable T-Mail compatible Hold flavour support in filebox directory name
+BoxesWithFlavours
+
 # Time in hour to wait file if it missing, if tick file was resived
 TickWaitHour 48
 

--- a/doc/README.ru
+++ b/doc/README.ru
@@ -1015,6 +1015,10 @@ AutoCreateFechoPath /home/ftp/fileecho
 # хардлинки.
 PassthroughtBoxesDir /var/spool/bt/fbox
 
+# Формировать имена каталогов транзитных файлбоксов с учетом flavour Hold
+# для совместимость с T-Mail или BinkD (добавлять ".H" в конце)
+BoxesWithFlavours
+
 # Время в часах, в течении которого ожидаем прихода файла для соотв. tic'а.
 TickWaitHour 168
 

--- a/src/common/tick.c
+++ b/src/common/tick.c
@@ -327,6 +327,12 @@ int tick_send(Tick * tic, Node * node, char *name, mode_t mode)
         str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
                    pass_path, node->zone, node->net, node->node, node->point);
 
+        /* 
+        * Check for BoxesWithFlavours support and add Hold flavour if needed
+        */
+        if (streq(flav, "Hold") && (cf_get_string("BoxesWithFlavours", TRUE) != NULL))
+            BUF_APPEND(buffer, ".H");
+
         if (mkdir_r(buffer, DIR_MODE) == ERROR) {
             fglog("$WARNING: can't create dir %s", buffer);
             return ERROR;
@@ -398,6 +404,13 @@ int tick_send(Tick * tic, Node * node, char *name, mode_t mode)
 
     str_printf(buffer, sizeof(buffer), "%s/%d.%d.%d.%d",
                pass_path, node->zone, node->net, node->node, node->point);
+
+    /* 
+     * Check for BoxesWithFlavours support and add Hold flavour if needed
+     */
+    if (streq(flav, "Hold") && (cf_get_string("BoxesWithFlavours", TRUE) != NULL))
+        BUF_APPEND(buffer, ".H");
+
     if (mkdir_r(buffer, DIR_MODE) == ERROR) {
         fglog("$ERROR: can't create dir %s", buffer);
         return ERROR;


### PR DESCRIPTION
Passthrough filebox directory name will include Hold flavour
attribute (.H) when BoxesWithFlavours is defined in fidogate.conf
and Tick flavour set to hold in routing.

Signed-off-by: Andriy Dzedolik <dz@dolik.dev>