### PR TITLE
Update fidogate.spec.in

### DIFF
--- a/packages/rpm/fidogate.spec.in
+++ b/packages/rpm/fidogate.spec.in
@@ -5,7 +5,7 @@ Release: 1%{?dist}
 License: GPLv2+
 Group: Fidonet/Gate
 Source0: https://github.com/ykaliuta/fidogate/archive/%{name}-%{version}.tar.gz
-BuildRequires: autoconf automake
+BuildRequires: autoconf automake byacc
 
 %description
 FIDOGATE Version 5


### PR DESCRIPTION
Adding dependence for RHEL build. Fixed bug
```
../build/ylwrap: line 175: yacc: command not found
make[3]: *** [Makefile:1334: common/parsedate.c] Error 127
```
Signed-off-by: Alexander Kruglikov 2:5053/58 alexandr@kruglikov.info