### PR TITLE
mime_header_enc: treat newline as whitespace, not part of a word

### DIFF
--- a/src/common/mime.c
+++ b/src/common/mime.c
@@ -830,7 +830,13 @@ int mime_header_enc(char **dst, char *src, char *charset, int enc)
         token = token_end;
 
         /* first skip spaces */
-        while ((*token_end == ' ' || *token_end == '\t' || *token == '\n')
+        /* NB: test the scan pointer token_end, not token. With "*token == '\n'"
+         * a newline at token_end was not treated as whitespace, so a trailing
+         * (or embedded) '\n' in the header value got swallowed into the word and
+         * MIME-encoded — producing a multi-line encoded-word like
+         * "=?utf-8?B?...0L4K?=" (the trailing "...\n" base64-encoded), which is an
+         * illegal multi-line header. Headers are single-line; '\n' is whitespace. */
+        while ((*token_end == ' ' || *token_end == '\t' || *token_end == '\n')
                && *token_end != '\0')
             token_end++;
 
@@ -840,7 +846,7 @@ int mime_header_enc(char **dst, char *src, char *charset, int enc)
         }
 
         /* then find next space or EOL */
-        while (*token_end != ' ' && *token_end != '\t' && *token != '\n'
+        while (*token_end != ' ' && *token_end != '\t' && *token_end != '\n'
                && *token_end != '\0')
             token_end++;
     }


### PR DESCRIPTION
## Problem

When gating an FTN message to RFC (`ftn2rfc`), a `Subject:` ending in non-ASCII text can be emitted as a malformed, multi-line encoded-word with a newline base64-encoded into the last word:

```
Subject: 09 =?utf-8?B?0LjRjtC90Y8g0LIg0LjRgdGC0L7RgNC40Lg?=
 =?utf-8?B?0L4K?=
```

The final encoded-word `=?utf-8?B?0L4K?=` decodes to `"о\n"` — i.e. it carries a trailing `0x0A`. That is an illegal header: a header is a single logical line and an RFC 2047 encoded-word must not contain CR/LF. Strict RFC 2047 / RFC 5322 readers render the decoded newline as a spurious blank line in the subject (and some reject it).

## Root cause

In `mime_header_enc()` the word scanner advances `token_end` but the whitespace tests check `*token` (the fixed word start) instead of `*token_end` for `'\n'`:

```c
while ((*token_end == ' ' || *token_end == '\t' || *token == '\n') ...)      /* skip spaces */
while (*token_end != ' ' && *token_end != '\t' && *token != '\n' ...)        /* find next sep */
```

So a `'\n'` at `token_end` is never treated as a separator; the value passed in is the full header line `"Subject: …\n"` (trailing newline from `tl_appendf(..., "%s\n")`), and that newline gets included in the word and MIME-encoded.

## Fix

Test `token_end` for `'\n'` as well, so newlines are handled as whitespace separators like space/tab (and dropped); the encoder re-folds output itself. Two-character change, behaviour otherwise unchanged.

## Test

Before: a Subject whose tail is non-ASCII gets a trailing-`\n` baked into the last encoded-word. After: the newline is treated as a separator and not encoded, yielding a valid single-logical-line Subject.